### PR TITLE
Changing the color of the facet labels

### DIFF
--- a/ggplot2.R
+++ b/ggplot2.R
@@ -41,6 +41,8 @@ theme_dracula <- function() {
       axis.text  = element_text(color = "#f8f8f2"),
       axis.title = element_text(face = "bold", color = "#6272A4"),
       
+      strip.text = element_text(face = "bold", colour="#6272A4"),
+      
       legend.background = element_rect(fill  = "transparent", color = NA),
       legend.key        = element_rect(fill  = "transparent", color = NA),
       legend.text       = element_text(color = "#f8f8f2"),


### PR DESCRIPTION
Your repository is absolutely amazing. 

When I used the theme with a faceted plot, I noticed that the labels are black (which is the default color, but which makes the labels difficult to see). 

Example:

````R
library(ggplot2)
library(palmerpenguins)

theme_set(theme_dracula())

ggplot(penguins, aes(x = island, fill = species)) +
  geom_bar(alpha = 0.8) +
  scale_fill_manual(values = dracula_palette(
    num_col  = nlevels(factor(penguins$species)),
    var_type = "discrete"
  )) +
  facet_wrap(~species, ncol = 1) 

````

![dracula_example_old](https://user-images.githubusercontent.com/21102900/214600051-8e5759d6-64c6-4a35-a7cf-423f69e5da6d.png)

So I'm hoping that my change will help this repository.

Change: 

```R
strip.text = element_text(face  = "bold", color = "#6272A4"),
```
![dracula_example](https://user-images.githubusercontent.com/21102900/214599622-c1053194-7f96-4171-b1a0-3ac3aa45ac65.png)
